### PR TITLE
Require $packages to compile

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,6 +27,7 @@ class statsite::install inherits statsite {
     cwd     => $version_path,
     command => 'make',
     creates => "${version_path}/statsite",
+    require => Package[$packages],
   }
 
   file { "${statsite::install_path}/current":


### PR DESCRIPTION
While ensure_packages() is called within install.pp, this doesn't seem to
actually guarantee that the dependencies are installed before trying to compile.

This adds the 'require' metaparameter to ensure that the packages are actually
installed before attempting to run make.
